### PR TITLE
Fix `endsWith` path check on Windows

### DIFF
--- a/mkdocs_monorepo_plugin/parser.py
+++ b/mkdocs_monorepo_plugin/parser.py
@@ -121,7 +121,7 @@ class IncludeNavLoader:
         return self.absNavPath
 
     def read(self):
-        if not self.absNavPath.endswith("/mkdocs.yml"):
+        if not self.absNavPath.endswith("mkdocs.yml"):
             log.critical(
                 "[mkdocs-monorepo] The included file path {} does not point to a mkdocs.yml".format(
                     self.absNavPath)


### PR DESCRIPTION
The `endsWith` check with the backslash causes `mkdocs serve/build` to fail when run on Windows. This commit removes this and just checks to see if the filename is correct.