### PR TITLE
Update page.file source path with original source, fixes #12

### DIFF
--- a/__tests__/integration/fixtures/ok-git-authors-plugin/docs/index.md
+++ b/__tests__/integration/fixtures/ok-git-authors-plugin/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/ok-git-authors-plugin/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-git-authors-plugin/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+  - git-authors
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+    - index.md
+  - Hello: "!include project-a/mkdocs.yml"

--- a/__tests__/integration/fixtures/ok-git-authors-plugin/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/ok-git-authors-plugin/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the ok-git-authors-plugin/project-a fixture.

--- a/__tests__/integration/fixtures/ok-git-authors-plugin/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-git-authors-plugin/project-a/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/docs/index.md
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/docs/index.md
@@ -1,0 +1,53 @@
+# Neptunia vapor
+
+## Has mente et
+
+Lorem markdownum aequora Famemque, a ramos regna Ulixem verba, posito qui
+nubilus membra. Pendet dixit canisve, hanc quoque animosa **veni**, inducere.
+Fer quem, mihi vallem; reposcunt aequoreae Haec, inposita. Eras dicere sic! Ore
+ad at nec pius rivi pectora Pandione amari pietas Ulixem.
+
+> Argenteus sinit. Corpore non Booten Uranie, in hac has dixi herbas. *Oculos
+> omnes Dixerat* suae coloribus et antris spernitque silva, dixit.
+
+Mihi [quamvis](http://caput-latebris.com/), ardua venit nam, de mox in et inquit
+incisa relevare reseminet Cycnus forma sororis. In mater artus utque iustis me
+vestrae magno datque, quaque multumque oscula iubemur.
+
+## Aditumque ubi
+
+Brevibus cervice inmunibus sunt peragit, [sua tanto
+insuper](http://ampycuslyncides.org/), arva ubi: torto mixta. Sanguis
+conscendunt sumit, utilis illo nec quaecumque ad urbis inpositaque. Alto sic
+esse resumere albet, pharetras sola, erat, [non longo
+paviunt](http://verba.org/) dives aurem. Nomina genus nulli insignia, carpere
+dare quo vident, *nox flemus sed* Telamon auras, erant illuc, tantum. Regia
+[duroque opto](http://www.flectathiberi.io/estredeunt), segetes paterna de
+crimen!
+
+    var edutainment_php = plain_ring_scan(adfUgcImap * delPanel);
+    var click_meta_dv = 3 +
+            systemScrollingDocument.snippetCdAnimated.memoryInstallHost(service(
+            bezel_trojan_plagiarism, 1, base_resources), intelligence,
+            umlWiSkin.software_olap.on(quadHocData));
+    var bare = jumper_server_solid - rupE + 3;
+    var timeRegistryStandby = disk_ppc_menu + gigahertzCifsRss;
+    if (im(correction_desktop, disk_integer_soft(serviceLogic, data_zone,
+            daw_ssid_web)) > graphicsExpansionBug + active) {
+        apiSpam = storageVisual + 3;
+    }
+
+Mors cum cum proturbat, gente nasci Semiramis sonum, toto est eris facto dapibus
+propulit; a! Rogantis ira canat, [in nec
+sanguine](http://acceptiordefensus.io/accepto) probro inmunesque molliter
+sustineat quem quamquam parentis non. Per **quod nec** rapit ipsa nec,
+territaque fallacis fluviis progenies aratro. Colla puer regesta si Haec
+silentia omen Paeonia, harenis puer Marmaridae pectora ingens miratur Thisbes
+veri. Plaga profugi, iram, praestans, pro hanc vehit, vites.
+
+Illa per acerris vivit difficile pulveris, faciebat pontus populabile utque? In
+flagrant umbrae marito, coniunx parari, **quoque sanguine Nisi**, ego
+[saxo](http://cervice-fessusque.com/), fovet, ait unda contigit. Gaudet in,
+herba quibus? Ore ne ambo mecumque pectoraque alta: viri illi in puer corpore
+expersque pharetra solutum proximitas. Gorgonis adempto, in montes terga quae
+nec remoratur nives perque insidias exsiluit tribuitque mille.

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: "Example"
+site_description: "Description Here"
+
+docs_dir: ./docs
+
+plugins:
+  - monorepo
+  - git-authors
+
+nav:
+  - Home: "index.md"
+  - Subnav:
+    - index.md
+    - index.md
+  - Hello: "!include project-a/mkdocs.yml"

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/mkdocs.yml
@@ -5,7 +5,7 @@ docs_dir: ./docs
 
 plugins:
   - monorepo
-  - git-authors
+  - git-revision-date-localized
 
 nav:
   - Home: "index.md"

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/docs/README.md
@@ -1,3 +1,3 @@
 # Hello world!
 
-This contains a sentence which only exists in the mkdocs-git-revision-date-localized-plugin/project-a fixture.
+This contains a sentence which only exists in the ok-mkdocs-git-revision-date-localized-plugin/project-a fixture.

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/docs/README.md
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/docs/README.md
@@ -1,0 +1,3 @@
+# Hello world!
+
+This contains a sentence which only exists in the mkdocs-git-revision-date-localized-plugin/project-a fixture.

--- a/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/mkdocs.yml
+++ b/__tests__/integration/fixtures/ok-mkdocs-git-revision-date-localized-plugin/project-a/mkdocs.yml
@@ -1,0 +1,8 @@
+site_name: 'test'
+site_description: 'This is a subdomain site.'
+
+plugins:
+  - monorepo
+
+nav:
+  - Home: README.md

--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -102,14 +102,14 @@ teardown() {
 @test "builds a mkdocs site with mkdocs-git-authors-plugin" {
   cd ${fixturesDir}/ok-git-authors-plugin
   assertSuccessMkdocs build
-  assertFileExists site/plugins/example-Folder/index.html
+  assertFileExists site/test/index.html
   [[ "$output" == *"This contains a sentence which only exists in the ok-git-authors-plugin/project-a fixture."* ]]
 }
 
 @test "builds a mkdocs site with mkdocs-git-revision-date-localized-plugin" {
   cd ${fixturesDir}/ok-mkdocs-git-revision-date-localized-plugin
   assertSuccessMkdocs build
-  assertFileExists site/plugins/example-Folder/index.html
+  assertFileExists site/test/index.html
   [[ "$output" == *"This contains a sentence which only exists in the ok-mkdocs-git-revision-date-localized-plugin/project-a fixture."* ]]
 }
 

--- a/__tests__/integration/test.bats
+++ b/__tests__/integration/test.bats
@@ -99,6 +99,20 @@ teardown() {
   [[ "$output" == *"This contains a sentence which only exists in the ok-nested-site-name-contains-slash/project-a fixture."* ]]
 }
 
+@test "builds a mkdocs site with mkdocs-git-authors-plugin" {
+  cd ${fixturesDir}/ok-git-authors-plugin
+  assertSuccessMkdocs build
+  assertFileExists site/plugins/example-Folder/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-git-authors-plugin/project-a fixture."* ]]
+}
+
+@test "builds a mkdocs site with mkdocs-git-revision-date-localized-plugin" {
+  cd ${fixturesDir}/ok-mkdocs-git-revision-date-localized-plugin
+  assertSuccessMkdocs build
+  assertFileExists site/plugins/example-Folder/index.html
+  [[ "$output" == *"This contains a sentence which only exists in the ok-mkdocs-git-revision-date-localized-plugin/project-a fixture."* ]]
+}
+
 @test "fails if !include path is above current folder" {
   cd ${fixturesDir}/error-include-path-is-parent
   assertFailedMkdocs build

--- a/__tests__/setup-bats.sh
+++ b/__tests__/setup-bats.sh
@@ -3,3 +3,4 @@
 sudo add-apt-repository ppa:duggan/bats
 sudo apt-get update
 sudo apt-get install bats
+sudo apt-get install git

--- a/__tests__/test-local.sh
+++ b/__tests__/test-local.sh
@@ -10,7 +10,7 @@ function docker_run_integration_tests() {
 docker build -t mkdocs-monorepo-test-runner:$1 --quiet -f- . <<EOF
   FROM python:$1
   COPY ./requirements.txt /workspace/requirements.txt
-  RUN apt-get -y update && apt-get -yyy install bats
+  RUN apt-get -y update && apt-get -yyy install bats && apt-get -yyy install git
   RUN pip install -r /workspace/requirements.txt
   ENTRYPOINT ["bats"]
   CMD ["/workspace/__tests__/integration/test.bats"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## 0.4.6
+
+- Fixes [compatibility issue with `mkdocs-git-revision-date-localized-plugin`](https://github.com/spotify/mkdocs-monorepo-plugin/issues/12)
+
 ## 0.4.5
+
 - Bumped up `mkdocs` to 1.1.1 and added compatibility (gh-16)
 
 ## 0.4.4

--- a/mkdocs_monorepo_plugin/merger.py
+++ b/mkdocs_monorepo_plugin/merger.py
@@ -17,6 +17,8 @@ from distutils.dir_util import copy_tree
 
 import logging
 import os
+from os import listdir
+from os.path import isfile, join
 
 from mkdocs.utils import warning_filter
 
@@ -32,6 +34,7 @@ class Merger:
         self.root_docs_dir = config['docs_dir']
         self.docs_dirs = list()
         self.append('', self.root_docs_dir)
+        self.files_source_dir = dict()
 
     def append(self, alias, docs_dir):
         self.docs_dirs.append([alias, docs_dir])
@@ -57,6 +60,11 @@ class Merger:
 
             if os.path.exists(source_dir):
                 copy_tree(source_dir, dest_dir)
+                files = [f for f in listdir(source_dir) if isfile(join(source_dir, f))]
+                for f in files:
+                    src = join(source_dir, f)
+                    dest = join(dest_dir, f)
+                    self.files_source_dir[dest] = src
             else:
                 log.critical(
                     "[mkdocs-monorepo] The {} path is not valid. ".format(source_dir) +
@@ -64,6 +72,9 @@ class Merger:
                 raise SystemExit(1)
 
         return str(self.temp_docs_dir.name)
+
+    def getFilesSourceFolder(self):
+        return self.files_source_dir
 
     def cleanup(self):
         return self.temp_docs_dir.cleanup()

--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -23,6 +23,7 @@ class MonorepoPlugin(BasePlugin):
         self.merger = None
         self.originalDocsDir = None
         self.resolvedPaths = []
+        self.files_source_dir = {}
 
     def on_config(self, config):
         # If no 'nav' defined, we don't need to run.
@@ -56,7 +57,9 @@ class MonorepoPlugin(BasePlugin):
 
     def on_pre_page(self, page, config, files):
         # Update page source attribute to point to source file
-        page.file.abs_src_path = self.files_source_dir[page.file.abs_src_path]
+        # Only in case any files were moved.
+        if len(self.files_source_dir) > 0:
+            page.file.abs_src_path = self.files_source_dir[page.file.abs_src_path]
         return page
 
     def on_serve(self, server, config):

--- a/mkdocs_monorepo_plugin/plugin.py
+++ b/mkdocs_monorepo_plugin/plugin.py
@@ -49,7 +49,15 @@ class MonorepoPlugin(BasePlugin):
         # Store resolved paths for later.
         self.resolvedPaths = resolvedPaths
 
+        # Store source directory of copied files for later
+        self.files_source_dir = self.merger.getFilesSourceFolder()
+
         return config
+
+    def on_pre_page(self, page, config, files):
+        # Update page source attribute to point to source file
+        page.file.abs_src_path = self.files_source_dir[page.file.abs_src_path]
+        return page
 
     def on_serve(self, server, config):
         buildfunc = list(server.watcher._tasks.values())[0]['func']

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 flake8>=3.7.8
 mkdocs>=1.1
 mkdocs-material>=5.1.0
+mkdocs-git-authors-plugin==0.3.2
+mkdocs-git-revision-date-localized-plugin==0.5.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='0.4.5',
+    version='0.4.6',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 
 setuptools.setup(
     name='mkdocs-monorepo-plugin',
-    version='0.4.4',
+    version='0.4.5',
     description='Plugin for adding monorepository support in Mkdocs.',
     long_description="""
         This introduces support for the !include syntax in mkdocs.yml, allowing you to import additional Mkdocs navigation.


### PR DESCRIPTION
This approach uses the `on_pre_page` event to update the page absolute source path attribute. It should fix issues when combining `mkdocs-monorepo-plugin` with plugins that depend on that attribute, like [mkdocs-git-authors-plugin](https://github.com/timvink/mkdocs-git-authors-plugin) and [mkdocs-git-revision-date-localized-plugin](https://github.com/timvink/mkdocs-git-revision-date-localized-plugin).